### PR TITLE
check Exception class in method _handleException

### DIFF
--- a/Model/SimpleQueue.php
+++ b/Model/SimpleQueue.php
@@ -205,8 +205,14 @@ class SimpleQueue {
 			'AWS.SimpleQueueService.NonExistentQueue'
 		);
 
-		if (in_array($e->getExceptionCode(), $fatalErrors) || $this->_exceptionCount >= 25) {
+		if ($this->_exceptionCount >= 25) {
 			throw $e;
+		}
+
+		if ($e instanceof Aws\Common\Exception\ServiceResponseException) {
+			if (in_array($e->getExceptionCode(), $fatalErrors)) {
+				throw $e;
+			}
 		}
 
 		$this->_exceptionCount++;


### PR DESCRIPTION
Add checking the exception that belongs to ServiceResponseException.
For example, exception is instance of ValidateException(illegal access to SQS returned message),
it has no method "getExceptionCode()".
In this case, "$e->getExceptionCode()" causes PHP Fatal Error.
