### PR TITLE
Added log message when worker finishes

### DIFF
--- a/src/Shell/Task/QueueWorkerTask.php
+++ b/src/Shell/Task/QueueWorkerTask.php
@@ -69,6 +69,7 @@ class QueueWorkerTask extends Shell
                 $i++;
             }
         }
+        $this->log(sprintf("Finished %s worker", $name), 'info', 'sqs');
     }
 
     /**


### PR DESCRIPTION
QueueWorkerTask::work() creates a log message when it starts but not when it finishes.

It would be good to have the finish message, too.