### PR TITLE
Add SIGHUP handling for graceful exit of worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,9 @@ messages are received from a set of queues in CakeSQS. This is an example
 The functions registered to handle jobs will receive the message body from the queue after decoding it using `json_decode`.
 
 IMPORTANT: return true to delete the message upon processing, false to leave the message in the queue and re - process later
+
+## Kill worker softly with SIGHUP
+
+To kill a long lived worker shell in the middle of the iterations loop, you can send SIGHUP by calling `kill -1 PID` on the commandline (PID is the process Id of your running worker shell).
+
+This will cause the current iteration to finish and stop the worker afterwards.


### PR DESCRIPTION
When I deploy a new version of my workers, I need to stop and start them.
To be able to do it all the time without terminating a running worker in the middle of an iteration, I added a handler for the SIGHUP (example: sent when you execute `kill -1 bin/cake.php worker workerName`).

It will listen to SIGHUP and check at the end of each iteration, whether there was a SIGHUP or not.
If there was a SIGHUP, then leave the while loop, even before the maximum number of `$iterations` is reached.