### PR TITLE
Fix queues in example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The plugin expects the following configuration data in the Configure keys:
             'region' => 'eu-central-1' // must match the region where the sqs queue was created
         ],
         'queues' => [
-            'queues.testQueue1' => 'sqs queue url, for example: https://sqs.eu-central-1.amazonaws.com/12345/someQueue'
+            'testQueue1' => 'sqs queue url, for example: https://sqs.eu-central-1.amazonaws.com/12345/someQueue'
         ]
     ]);
 


### PR DESCRIPTION
You had an extra `queues` in there. I'm pretty sure that was just copy-pasta from the below `$this->SimpleQueue->setConfig()` call, which does need the extra `queues`.